### PR TITLE
Compatibility fixes for older SDCC versions

### DIFF
--- a/Firmware/include/rules.mk
+++ b/Firmware/include/rules.mk
@@ -72,11 +72,21 @@ PRODUCT_INSTALL	?=	$(PRODUCT_HEX)
 # Compiler and tools
 #
 ifeq ($(shell which sdcc),)
-$(error Could not find SDCC on your path - cannot build)
+	ifeq ($(shell which sdcc-sdcc),)
+		$(error Could not find SDCC on your path - cannot build)
+	else
+		# CentOS SDCC binaries are prefixed
+		SDCC = sdcc-sdcc
+		SDAS = sdcc-sdas8051
+	endif
+else
+	# Standard SDCC binaries
+	SDCC = sdcc
+	SDAS = sdas8051
 endif
-CC		 =	sdcc -mmcs51
-AS		 =	sdas8051 -jloscp
-LD		 =	sdcc
+CC		 =	$(SDCC) -mmcs51
+AS		 =	$(SDAS) -jloscp
+LD		 =	$(SDCC)
 MD5		 =	md5
 BANK_ALLOC	 =	./tools/bank-alloc.py
 INCLUDES	 =	$(SRCROOT)/include

--- a/Firmware/radio/i2c.c
+++ b/Firmware/radio/i2c.c
@@ -238,9 +238,10 @@ char eeprom_read_page(unsigned short address)
   
 char eeprom_read_next_page(unsigned short address)
 {
+  unsigned char i;
   if (i2c_tx(0xa1+((address>>7)&0xe))) { i2c_stop(); return 6; }
-  
-  for(unsigned char i=0;i<15;i++) {
+
+  for(i=0;i<15;i++) {
     eeprom_data[i]=i2c_rx(1);
     if (read_error) {
       i2c_stop();
@@ -290,6 +291,7 @@ char eeprom_write_byte(unsigned short address, unsigned char value)
 char eeprom_write_page(unsigned short address)
 {
   uint8_t waiting=1;
+  char i;
   i2c_start();
 
   // Due to slowness, show pretty lights while writing
@@ -298,7 +300,7 @@ char eeprom_write_page(unsigned short address)
   
   if (i2c_tx(0xa0+((address>>7)&0xe))) goto fail;
   if (i2c_tx(address&0xff)) goto fail;
-  for(char i=0;i<16;i++) {
+  for(i=0;i<16;i++) {
     if (i2c_tx(eeprom_data[i])) goto fail;
     printfl(" %x",eeprom_data[i]);
 

--- a/Firmware/radio/sha3.c
+++ b/Firmware/radio/sha3.c
@@ -167,19 +167,19 @@ static void keccakf(void)
 void sha3_Init256(void)
 {
     memset(&ctx, 0, sizeof(ctx));
-    ctx.capacityWords = 2 * 256 / (8 * sizeof(uint64_t));
+    ctx.capacityWords = 2 * 256 / (8 * UINT64_SIZE);
 }
 
 void sha3_Init384(void)
 {
     memset(&ctx, 0, sizeof(ctx));
-    ctx.capacityWords = 2 * 384 / (8 * sizeof(uint64_t));
+    ctx.capacityWords = 2 * 384 / (8 * UINT64_SIZE);
 }
 
 void sha3_Init512(void)
 {
     memset(&ctx, 0, sizeof(ctx));
-    ctx.capacityWords = 2 * 512 / (8 * sizeof(uint64_t));
+    ctx.capacityWords = 2 * 512 / (8 * UINT64_SIZE);
 }
 
 __xdata uint32_t old_tail;

--- a/Firmware/radio/sha3.h
+++ b/Firmware/radio/sha3.h
@@ -43,13 +43,23 @@
 #define SHA3_CONST(x) x##L
 #endif
 
+/* 
+ * Some versions of SDCC (3.4.0 from CentOS7) don't support 64-bit 
+ * integer types on mcs51 - see __SDCC_LONGLONG in stdint.h
+ */
+#if defined(__SDCC_mcs51)
+#define UINT64_SIZE 8
+#else
+#define UINT64_SIZE sizeof(uint64_t)
+#endif
+
 /* The following state definition should normally be in a separate 
  * header file 
  */
 
 /* 'Words' here refers to uint64_t */
 #define SHA3_KECCAK_SPONGE_WORDS \
-        (((1600)/8/*bits to byte*/)/sizeof(uint64_t))
+        (((1600)/8/*bits to byte*/)/UINT64_SIZE)
 struct sha3_context {
     uint8_t saved[8];             /* the portion of the input message that we
                                  * didn't consume yet */


### PR DESCRIPTION
Enables clean compilation using native SDCC 3.4.0 RPM on CentOS, via 3 changes:
- if standard SDCC binaries are not found, also try CentOS-specific SDCC binary names (sdcc-sdcc, sdcc-sdas etc)
- replace last remaining 64-bit references in SHA3 code with constants
- convert inline variable definitions (c99-ism) to c89 style
